### PR TITLE
Hotkeys reimplemented with keyboard hook and self-contained in widget

### DIFF
--- a/pypipboyapp.py
+++ b/pypipboyapp.py
@@ -430,8 +430,7 @@ class PyPipboyApp(QtWidgets.QApplication):
         
             
     def setStyle(self, name):
-        name = self.styles.get(name, 'default')
-        if name == 'default':
+        if (name == 'default' or not name in self.styles):
             self.setStyleSheet('')
         else:
             style = self.styles[name]

--- a/pypipboyapp.py
+++ b/pypipboyapp.py
@@ -430,6 +430,7 @@ class PyPipboyApp(QtWidgets.QApplication):
         
             
     def setStyle(self, name):
+        name = self.styles.get(name, 'default')
         if name == 'default':
             self.setStyleSheet('')
         else:


### PR DESCRIPTION
I've rewritten the hotkey implementation so it's usable by normal people:
- Completely self contained within the widget, with an platform specific guard on creation (is that enough for cross platform compatibility, or is the pywin32 dependency a bigger problem than I realise?)
- Implemented with a keyboard hook, so only effective when Fallout4 has focus
- Rudimentary, but functional, UI for configuring hotkeys
