### PR TITLE
Move faulthandler to later in startup for compatibility with pythonw

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ __pycache__
 /widgets/playerinfo/res/*.png
 /pypipboy/
 THumbs.db
+log.txt

--- a/pypipboyapp.py
+++ b/pypipboyapp.py
@@ -730,7 +730,6 @@ class PyPipboyApp(QtWidgets.QApplication):
             
 # Main entry point
 if __name__ == "__main__":
-    #faulthandler.enable()
     stdlogfile = None
     i = 1
     while i < len(sys.argv):
@@ -750,6 +749,18 @@ if __name__ == "__main__":
     except Exception as e:
         logging.basicConfig(level=logging.WARN)
         logging.error('Error while reading logging config: ' + str(e))
+
+    try:
+        faulthandler.enable()
+    except Exception as e:
+        logging.error('Error calling Faulthandle.enable(): ' + str(e))
+        
+    if (faulthandler.is_enabled()):
+        logging.warn('Faulthandler is enabled')
+        #faulthandler.dump_traceback_later(5)
+    else:
+        logging.error('Faulthandler is NOT enabled')
+
     if 'nt' in os.name:
         from ctypes import windll
         windll.shell32.SetCurrentProcessExplicitAppUserModelID(u'matzman666.pypipboyapp')


### PR DESCRIPTION
Looks like the faulthandler problem was with pythonw in general, probably due to the fact that it makes stderr and stdout null by default. Moving it to after they are redirected to a file seems to work okay for both python and pythonw (although if pythonw is started without the --stdlog argument it's going to fail, hence the try\catch).
